### PR TITLE
Adding migration support and delete cascade migration for space references

### DIFF
--- a/models/migrations/01-spaces-delete-cascade.js
+++ b/models/migrations/01-spaces-delete-cascade.js
@@ -1,0 +1,80 @@
+'use strict';
+
+module.exports = {
+  up: function(migration, DataTypes) {
+    return [
+      migration.changeColumn('memberships', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE'
+        }
+      ),
+      migration.changeColumn('artifacts', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE'
+        }
+      ),
+      migration.changeColumn('messages', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE'
+        }
+      )
+    ]
+  },
+
+  down: function(migration, DataTypes) {
+    return [
+      migration.changeColumn('memberships', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'NO ACTION'
+        }
+      ),
+      ,
+      migration.changeColumn('artifacts', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'NO ACTION'
+        }
+      ),
+      migration.changeColumn('messages', 'space_id',
+        {
+          type: DataTypes.STRING,
+          references: {
+            model: 'spaces',
+            key: '_id'
+          },
+          onDelete: 'CASCADE',
+          onUpdate: 'NO ACTION'
+        }
+      )
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "slug": "0.9.1",
     "sqlite3": "^4.0.0",
     "swig": "1.4.2",
+    "umzug": "^2.1.0",
     "underscore": "1.8.3",
     "uuid": "^3.2.1",
     "validator": "7.0.0",


### PR DESCRIPTION
It fixes https://github.com/spacedeck/spacedeck-open/issues/23

When using sqlite we need to set explicitly on delete to cascade. I've added basic migrations with Umzug (yet included in the package.json) to do the upgrade.