### PR TITLE
Introduce API Token and Embedding Features, WordPress Integration

### DIFF
--- a/integrations/wordpress/plugins/spacedeck/spacedeck.php
+++ b/integrations/wordpress/plugins/spacedeck/spacedeck.php
@@ -1,0 +1,202 @@
+<?php
+/*
+  Plugin Name: Spacedeck
+  Plugin URI: https://spacedeck.com
+  description: Embed Spacedeck Whiteboards in Wordpress Posts
+  Version: 1.0
+  Author: MNT Research GmbH
+  Author URI: https://mntre.com
+  License: GPLv3+
+*/
+
+add_option("spacedeck_settings");
+
+function spacedeck_apicall($method, $path, $data) {
+	$spacedeck_api_base_uri = get_option("spacedeck_settings")[spacedeck_api_base_uri];
+	$spacedeck_api_key = get_option("spacedeck_settings")[spacedeck_api_key];
+	
+	$data_string = json_encode($data);
+	$url = $spacedeck_api_base_uri . $path;
+
+	$headers = array(
+		'Content-Type' => 'application/json',
+		'X-Spacedeck-API-Token' => $spacedeck_api_key
+	);
+	
+	$payload = array(
+		'method' => $method,
+		'timeout' => 10,
+		'blocking' => true,
+		'headers' => $headers,
+		'body' => $data_string
+	);
+
+	// echo("<p>payload:</p><pre>");
+	// print_r($payload);
+	// echo("</pre>");
+	
+	$result = wp_remote_post($url, $payload);
+
+	if (is_wp_error($result)) {
+		return $result;
+	}
+
+	$result = json_decode($result[body], true);
+
+	// echo("<p>decoded:</p><pre>");
+	// print_r($result);
+	// echo("</pre>");
+	
+	return $result;
+}
+
+function spacedeck_embed_space($slug, $width = '90%', $height = '800', $parent_space_id = null) {
+	$spacedeck_frontend_base_uri = get_option("spacedeck_settings")[spacedeck_frontend_base_uri];
+
+	// try to find the space identified by slug
+	$space = spacedeck_apicall("GET", "/spaces/" . $slug, array());
+
+	if (is_wp_error($space)) {
+		$error = $response->get_error_message();
+		return("<p><b>Spacedeck: WP Error looking up Space: $error</b></p>");
+	} else if ($space[error] && $space[error]!="space_not_found") {
+		return("<p><b>Spacedeck: Error looking up Space: $space[error]</b></p>");
+	}
+
+	// if it doesn't exist, create it:
+	if ($space[error]=="space_not_found") {
+		$data = array(
+			"name" => $slug,
+			"edit_slug" => $slug
+		);
+
+		if ($parent_space_id) {
+			$data[parent_space_id] = $parent_space_id;
+		}
+		
+		$space = spacedeck_apicall("POST", "/spaces", $data);
+
+		if (is_wp_error($space)) {
+			$error = $response->get_error_message();
+			return("<p><b>Spacedeck: WP Error creating Space: $error</b></p>");
+		} else if ($space[error]) {
+			return("<p><b>Spacedeck: Error creating Space: $space[error]</b></p>");
+		}
+	}
+
+	if (is_wp_error($space)) {
+		$error = $response->get_error_message();
+		return("<p><b>Spacedeck: WP Error embedding Space: $error</b></p>");
+	} else if (!$space || $space[error]) {
+		return("<p><b>Spacedeck: Error embedding Space. Is your API key set up correctly?</b></p>");
+	}
+
+	$space_auth = $space[edit_hash];
+	
+	// return a piece of html (iframe) embedding the space
+	$uri = $spacedeck_frontend_base_uri . '/spaces/' . $slug . '?embedded=1&spaceAuth=' . $space_auth;
+		
+	$html = "<iframe src='$uri' class='spacedeck' width='$width' height='$height' style='max-width:100%' frameborder='0' allowFullScreen='true'></iframe>";
+
+	return $html;
+}
+
+function spacedeck_shortcode($attrs) {
+	extract(shortcode_atts(array(
+		'id' => 'none',
+		'parent_space_id' => null,
+		'width' => '100%',
+		'height' => '800'
+	), $attrs));
+
+	$w = $attrs[width];
+	$h = $attrs[height];
+	if (!$w) $w = '100%';
+	if (!$h) $h = 800;
+
+	return spacedeck_embed_space($attrs[id],$w,$h,$attrs[parent_space_id]);
+}
+
+add_shortcode('spacedeck_space', 'spacedeck_shortcode');
+
+add_action('admin_menu', 'spacedeck_add_admin_menu');
+add_action('admin_init', 'spacedeck_settings_init');
+
+function spacedeck_add_admin_menu() { 
+	add_options_page('spacedeck', 'Spacedeck', 'manage_options', 'spacedeck', 'spacedeck_options_page');
+}
+
+function spacedeck_settings_init() { 
+	register_setting('pluginPage', 'spacedeck_settings');
+
+	add_settings_section(
+		'spacedeck_pluginPage_section', 
+		'Spacedeck Settings', 
+		'spacedeck_settings_section_callback', 
+		'pluginPage'
+	);
+
+	add_settings_field(
+		'spacedeck_text_field_0', 
+		'API key',
+		'spacedeck_text_field_0_render', 
+		'pluginPage', 
+		'spacedeck_pluginPage_section' 
+	);
+
+	add_settings_field(
+		'spacedeck_text_field_1', 
+		'API base URL', 
+		'spacedeck_text_field_1_render', 
+		'pluginPage', 
+		'spacedeck_pluginPage_section' 
+	);
+
+	add_settings_field(
+		'spacedeck_text_field_2', 
+		'Frontend base URL',
+		'spacedeck_text_field_2_render', 
+		'pluginPage',
+		'spacedeck_pluginPage_section' 
+	);
+}
+
+function spacedeck_text_field_0_render() {
+	$opts = get_option('spacedeck_settings');
+	?>
+	<input type='text' name='spacedeck_settings[spacedeck_api_key]' value='<?php echo $opts[spacedeck_api_key]; ?>'>
+<?php
+}
+
+function spacedeck_text_field_1_render() { 
+	$opts = get_option('spacedeck_settings');
+	?>
+	<input type='text' name='spacedeck_settings[spacedeck_api_base_uri]' value='<?php echo $opts[spacedeck_api_base_uri]; ?>'>
+<?php
+}
+
+function spacedeck_text_field_2_render() { 
+	$opts = get_option('spacedeck_settings');
+	?>
+	<input type='text' name='spacedeck_settings[spacedeck_frontend_base_uri]' value='<?php echo $opts[spacedeck_frontend_base_uri]; ?>'>
+<?php
+}
+
+function spacedeck_settings_section_callback() { 
+	echo '';
+}
+
+function spacedeck_options_page() {
+	?>
+	<form action='options.php' method='post'>
+<?php
+	settings_fields('pluginPage');
+	do_settings_sections('pluginPage');
+	submit_button();
+	?>
+	</form>
+<?php
+}
+
+
+?>

--- a/middlewares/space_helpers.js
+++ b/middlewares/space_helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const db = require('../models/db');
+const { Op } = require("sequelize");
 var config = require('config');
 
 module.exports = (req, res, next) => {
@@ -53,8 +54,12 @@ module.exports = (req, res, next) => {
     'email': 1
   };
 
+  // find space by id or slug
   db.Space.findOne({where: {
-    "_id": spaceId
+                    [Op.or]: [
+                      {"_id": spaceId},
+                      {"edit_slug": spaceId}
+                    ]
   }}).then(function(space) {
 
     if (space) {

--- a/models/db.js
+++ b/models/db.js
@@ -51,6 +51,17 @@ module.exports = {
     updated_at: {type: Sequelize.DATE, defaultValue: Sequelize.NOW}
   }),
 
+  CreatorSafeInclude: function(db) {
+    return {
+      model: this.User,
+      as: 'creator',
+      attributes: ['_id','email','nickname',
+                   'avatar_original_uri',
+                   'avatar_thumb_uri',
+                   'created_at','updated_at']
+    };
+  },
+
   Session: sequelize.define('session', {
     token: {type: Sequelize.STRING, primaryKey: true},
     user_id: Sequelize.STRING,

--- a/models/db.js
+++ b/models/db.js
@@ -42,6 +42,7 @@ module.exports = {
     avatar_thumb_uri: Sequelize.STRING,
     confirmation_token: Sequelize.STRING,
     password_reset_token: Sequelize.STRING,
+    api_token: Sequelize.STRING,
     home_folder_id: Sequelize.STRING,
     prefs_language: Sequelize.STRING,
     prefs_email_notifications: Sequelize.STRING,

--- a/models/migrations/02-users-add-api-token.js
+++ b/models/migrations/02-users-add-api-token.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: function(migration, DataTypes) {
+    return Promise.all([
+      migration.addColumn('users', 'api_token',
+        {
+          type: DataTypes.STRING
+        }
+      )
+    ])
+  },
+
+  down: function(migration, DataTypes) {
+    return Promise.all([
+      migration.removeColumn('users', 'api_token')
+    ])
+  }
+}

--- a/public/javascripts/spacedeck_spaces.js
+++ b/public/javascripts/spacedeck_spaces.js
@@ -100,12 +100,12 @@ var SpacedeckSpaces = {
     },
     
     load_space: function(space_id, on_success, on_error) {
-
-      console.log("load space: ", space_id);
       this.folder_spaces_filter="";
       this.folder_spaces_search="";
 
       space_auth = get_query_param("spaceAuth");
+
+      this.embedded = !!(get_query_param("embedded"));
 
       var userReady = function() {
         this.close_dropdown();
@@ -649,6 +649,13 @@ var SpacedeckSpaces = {
       this.present_mode = !this.present_mode;
       if (this.present_mode) {
         //this.go_to_first_zone();
+        if (this.embedded) {
+          document.documentElement.requestFullscreen();
+        }
+      } else {
+        if (this.embedded) {
+          document.exitFullscreen();
+        }
       }
     },
 

--- a/public/javascripts/spacedeck_users.js
+++ b/public/javascripts/spacedeck_users.js
@@ -17,7 +17,6 @@ SpacedeckUsers = {
     loading_user: false,
     password_reset_confirm_error: "",
     password_reset_error: "",
-    
   },
   methods:{
     load_user: function(on_success, on_error) {

--- a/public/javascripts/spacedeck_vue.js
+++ b/public/javascripts/spacedeck_vue.js
@@ -14,6 +14,7 @@ function boot_spacedeck() {
     account: "profile",
     logged_in: false,
     guest_nickname: null,
+    embedded: false,
     user: {},
 
     active_profile: null,

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -14548,9 +14548,6 @@ button.close {
   position: relative;
   overflow: scroll; }
   .board .wrapper {
-    border: 4px solid black;
-    transition-duration: 0.25s;
-    transition-property: width, height, background-color;
     background-repeat: no-repeat;
     background-size: cover; }
 

--- a/spacedeck.js
+++ b/spacedeck.js
@@ -71,18 +71,18 @@ app.use(bodyParser.urlencoded({
 }));
 
 app.use(cookieParser());
-app.use(helmet.frameguard())
-app.use(helmet.xssFilter())
-app.use(helmet.hsts({
+//app.use(helmet.frameguard())
+//app.use(helmet.xssFilter())
+/*app.use(helmet.hsts({
   maxAge: 7776000000,
   includeSubDomains: true
-}))
+}))*/
 app.disable('x-powered-by');
-app.use(helmet.noSniff())
+//app.use(helmet.noSniff())
 
 //app.use(require("./middlewares/error_helpers"));
-app.use(require("./middlewares/session"));
 //app.use(require("./middlewares/cors"));
+app.use(require("./middlewares/session"));
 app.use(require("./middlewares/i18n"));
 app.use("/api", require("./middlewares/api_helpers"));
 app.use('/api/spaces/:id', require("./middlewares/space_helpers"));

--- a/styles/space-sections.scss
+++ b/styles/space-sections.scss
@@ -118,10 +118,6 @@
   padding: 0 !important;
 
   .wrapper {
-    border: 4px solid black;
-
-    transition-duration: 0.25s;
-    transition-property: width, height, background-color;
     background-repeat: no-repeat;
     background-size: cover;
   }

--- a/views/partials/account.html
+++ b/views/partials/account.html
@@ -55,6 +55,15 @@
       </div>
 
       <div>
+        <div class="form-group">
+          <label class="label">API Token</label>
+          <input
+          type="text"
+          id="api-token"
+          class="input input-white no-b"
+          v-model="user.api_token"
+          placeholder="secret key">
+        </div>
 
         <div class="form-group">
           <label class="label" >[[__("profile_name")]]</label>
@@ -67,18 +76,17 @@
 
         <div class="form-group">
           <label class="label">[[__("profile_email")]]</label>
-
           <input
-          id="new-email"
-          v-bind:class="{disabled: user.account_type=='google'}"
-          v-bind:disabled="user.account_type=='google'"
-          class="input input-white no-b"
           type="email"
+          id="new-email"
+          class="input input-white no-b"
           v-model="user.email"
           v-on:change="user.email_changed=true"
           placeholder="mail@example.com">
+        </div>
 
-          <button class="btn btn-md btn-dark" v-on:click=" save_user()" style="margin-top:20px">Save</button>
+        <div class="form-group">
+          <button class="btn btn-md btn-dark" v-on:click="save_user()">Save</button>
         </div>
       </div>
     </div>

--- a/views/partials/tool/toolbar-elements.html
+++ b/views/partials/tool/toolbar-elements.html
@@ -4,14 +4,14 @@
     
     <a class="btn btn-icon btn-transparent"
        title="[[__("home")]]" href="/spaces"
-       v-if="(!active_space.parent_space_id && !guest_nickname)">
+       v-if="(!active_space.parent_space_id && !guest_nickname && !embedded)">
       <span class="icon icon-folder"></span>
     </a>
       
     <a class="btn btn-icon btn-dark"
        title="Parent Folder"
        href="/folders/{{active_space.parent_space_id}}"
-       v-if="(active_space.parent_space_id && !guest_nickname)">
+       v-if="(active_space.parent_space_id && !guest_nickname && !embedded)">
       
       <span class="icon icon-sd6 icon-svg"></span>
     </a>


### PR DESCRIPTION
This PR includes:

- The ability for an API client to authenticate as a user via a fixed api_token set in the user profile. API clients authenticate via a new header `X-Spacedeck-API-Token`
- The ability to address the space resource directly via a slug and not only the internal ID, i.e. `/spaces/my-new-space`
- A URL query parameter ?embed=1 for the frontend to hide the Home button in Spaces, and to toggle fullscreen for Present mode
- A demo integration as a WordPress plugin. This allows you to embed Spaces in Posts/Pages via a shortcode like `[spacedeck_space id=slug]`. If a Space with the fitting slug is not found, it is automatically created. The API key and base URLs must be set up in the Settings pane for Spacedeck in WordPress admin.
