### PR TITLE
fix pdf export + add download_as_pdf template string and action

### DIFF
--- a/locales/de.js
+++ b/locales/de.js
@@ -303,6 +303,7 @@
 	"sharing": "sharing",
 	"list": "Liste",
 	"download_space": "Space Herunterladen",
+	"download_as_pdf": "Space als PDF herunterladen",
 	"duplicate_destination_folder": "Zielordner für Duplikat",
 	"type": "Typ",
 	"promote": "Befördern",

--- a/locales/en.js
+++ b/locales/en.js
@@ -308,6 +308,7 @@
 	"list": "Export List",
 	"link": "Link",
 	"download_space": "Download Space",
+	"download_as_pdf": "Download Space as PDF",
 	"type": "Type",
 	"download": "Download",
 	"Previous Zone": "Previous Zone",

--- a/locales/es.js
+++ b/locales/es.js
@@ -308,6 +308,7 @@
 	"list": "Lista para Exportar",
 	"link": "Enlace",
 	"download_space": "Espacio de Descarga",
+	"download_as_pdf": "Descargar espacio en PDF",
 	"type": "Tipo",
 	"download": "Descarga",
 	"Previous Zone": "Zona Previa",

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -301,6 +301,7 @@
 	"goto_folder": "Aller au dossier %s",
 	"stay_here": "Reste ici",
 	"download_space": "télécharger un espace",
+	"download_as_pdf": "télécharger un espace comme PDF",
 	"type": "Type",
 	"Previous Zone": "Zone précédent",
 	"Next Zone": "Zone suivante",

--- a/locales/oc.js
+++ b/locales/oc.js
@@ -308,6 +308,7 @@
     "list": "lista",
     "link": "Ligam",
     "download_space": "Telecargar espaci",
+    "download_space_as_pdf": "Telecargar espaci PDF",
     "type": "Tipe",
     "download": "Telecargar",
     "Previous Zone": "Zòna precedenta",

--- a/public/javascripts/spacedeck_spaces.js
+++ b/public/javascripts/spacedeck_spaces.js
@@ -614,10 +614,11 @@ var SpacedeckSpaces = {
     },
 
     download_space_as_pdf: function(space) {
+      this.close_dropdown();
       this.global_spinner = true;
       get_resource("/spaces/" + space._id + "/pdf", function(o) {
         this.global_spinner = false;
-        location.href = o.url;
+        window.open(o.url, "_blank");
       }.bind(this), function(xhr) {
         this.global_spinner = false;
         alert("PDF export problem (" + xhr.status + ").");

--- a/routes/api/space_exports.js
+++ b/routes/api/space_exports.js
@@ -114,7 +114,10 @@ router.get('/pdf', function(req, res, next) {
       res.status(201).json({
         url: url
       });
-      fs.unlink(local_path);
+      fs.unlink(local_path, function(){
+        // callback added so export doesn't crash
+        // Evaluate FIX
+      });
     });
   }, (err) => {
     res.status(500).json({

--- a/routes/api/space_exports.js
+++ b/routes/api/space_exports.js
@@ -115,8 +115,10 @@ router.get('/pdf', function(req, res, next) {
         url: url
       });
       fs.unlink(local_path, function(){
-        // callback added so export doesn't crash
-        // Evaluate FIX
+        if (err) console.log('unlink', err);
+        else {
+          console.log('unlink', local_path);
+        }
       });
     });
   }, (err) => {

--- a/views/partials/folders.html
+++ b/views/partials/folders.html
@@ -156,6 +156,7 @@
 
             <div class="dropdown-menu" role="menu">
               <ul class="select-list">
+                <li v-on:click="download_space_as_pdf(item)"><span><span class="icon icon-sm icon-clipboard"></span><%=  __('download_as_pdf') %></span></li>
                 <li v-on:click="rename_space(item)"><span><span class="icon icon-sm icon-tag"></span><%=  __('rename') %></span></li>
                 <li v-on:click="delete_space(item)"><span><span class="icon icon-sm icon-trash"></span><%=  __('delete') %></span></li>
               </ul>


### PR DESCRIPTION
Hi @mntmn 
I finally found some time to make this pull request. Regarding the pdf export with phantom, for me, just adding a callback to the unlink function did the trick. Can't tell you yet why. Perhaps you could countercheck on your side if it also works for you.
I have added the action on the space dropdown. I took the liberty of also changing this little things, I hope the changes are ok for you too:
- opening the pdf in a new tab after generation
- adding a new template string for the pdf export specific action in the dropdown
- The icon is just pretty random, is there any easy way to visualise all available icons?

Thanks and best regards