### PR TITLE
top-left align thumbs instead of bg cover

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -12651,13 +12651,12 @@ button.close {
         position: absolute;
         width: 100%;
         overflow: hidden;
-        background-size: cover;
         background-color: transparent;
         border-top-left-radius: 6px;
         border-top-right-radius: 6px;
         border-bottom-left-radius: 10px;
         border-bottom-right-radius: 10px;
-        background-position: center 100%;
+        background-position: left top;
         background-repeat: no-repeat; }
       #folder-grid .item > a .item-title {
         display: block;

--- a/styles/folder.scss
+++ b/styles/folder.scss
@@ -419,14 +419,13 @@
         width: 100%;
         overflow: hidden;
 
-        background-size: cover;
         background-color: transparent;
         border-top-left-radius: $radius*2;
         border-top-right-radius: $radius*2;
 
         border-bottom-left-radius: 10px;
         border-bottom-right-radius: 10px;
-        background-position: center 100%;
+        background-position: left top;
         background-repeat: no-repeat;
       }
 


### PR DESCRIPTION
Hi @mntmn 
this is probably just a personal preference, but it gives me the impression that I have more control over how the thumbs in the overview look just by starting my drawings next to the 0:0 position of the canvas. If there is no other reason I didn't think of why to use the bg cover option I would propose to change that.