### PR TITLE
Data type `TEXT` used for `artifact.shape_svg`.

### DIFF
--- a/models/db.js
+++ b/models/db.js
@@ -175,7 +175,7 @@ module.exports = {
     crop_w: Sequelize.INTEGER,
     crop_h: Sequelize.INTEGER,
     shape: Sequelize.STRING,
-    shape_svg: Sequelize.STRING,
+    shape_svg: Sequelize.TEXT,
     padding_left: Sequelize.INTEGER,
     padding_right: Sequelize.INTEGER,
     padding_top: Sequelize.INTEGER,


### PR DESCRIPTION
Based on the [issue#113](https://github.com/spacedeck/spacedeck-open/issues/113), this pull request contains the change in the data type of `artifact.shape_svg`.