### PR TITLE
stroke color and width are now taken from current selection (#82)

### DIFF
--- a/public/javascripts/spacedeck_whiteboard.js
+++ b/public/javascripts/spacedeck_whiteboard.js
@@ -588,8 +588,8 @@ function setup_whiteboard_directives() {
         z: z,
         w: 64,
         h: 64,
-        stroke_color: $scope.active_style.stroke_color,
-        stroke: 2,
+        stroke_color: $scope.active_style.stroke_color == "rgba(0,0,0,0)" ? "rgba(0,0,0,255)" : $scope.active_style.stroke_color,
+        stroke: $scope.active_style.stroke == 0 ? 2 : $scope.active_style.stroke,
         shape: "scribble"
       };
 
@@ -624,8 +624,8 @@ function setup_whiteboard_directives() {
         z: z,
         w: 64,
         h: 64,
-        stroke_color: $scope.active_style.stroke_color,
-        stroke: 2,
+        stroke_color: $scope.active_style.stroke_color == "rgba(0,0,0,0)" ? "rgba(0,0,0,255)" : $scope.active_style.stroke_color,
+        stroke: $scope.active_style.stroke == 0 ? 2 : $scope.active_style.stroke,
         shape: "arrow"
       };
 


### PR DESCRIPTION
When using the scribble or arrow tool the stroke color and stroke width will be set to the stroke color or width of the currently selected item. If stroke width is 0 it will default to two. if stroke color is transparent it will default to black.