### PR TITLE
put z-index of lock icon higher

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -14983,7 +14983,8 @@ button.close {
     text-align: center;
     max-width: 100%;
     overflow-x: hidden;
-    margin-top: -3em; }
+    margin-top: -3em;
+    z-index: 100; }
   .artifact .edit {
     position: absolute;
     top: 10px;

--- a/styles/artifact.scss
+++ b/styles/artifact.scss
@@ -49,6 +49,7 @@
     max-width: 100%;
     overflow-x: hidden;
     margin-top: -3em;
+    z-index: 100;
   }
 
   .edit {


### PR DESCRIPTION
- quick fix to show the lock icon in front of the shape artefact. Just put an arbitrary z-index, please change according to what makes sense. Thanks.