### PR TITLE
Fix space_auth being overriden by unused parameter, add 'nickname' GET param

### DIFF
--- a/public/javascripts/spacedeck_spaces.js
+++ b/public/javascripts/spacedeck_spaces.js
@@ -99,7 +99,7 @@ var SpacedeckSpaces = {
       }.bind(this), {value: dft || "Guest "+parseInt(10000*Math.random()), ok: __("ok"), cancel: __("cancel")});
     },
     
-    load_space: function(space_id, on_success, on_error, space_auth) {
+    load_space: function(space_id, on_success, on_error) {
       this.folder_spaces_filter="";
       this.folder_spaces_search="";
 
@@ -308,7 +308,8 @@ var SpacedeckSpaces = {
         userReady();
       }
 
-      if (!this.user && space_auth) {
+      if (!this.user.nickname && space_auth) {
+        this.guest_nickname = get_query_param("nickname") || this.guest_nickname;
         if (this.guest_nickname) {
           userReady();
         } else {


### PR DESCRIPTION
Hi there. Very nice whiteboard app!

I think there were a few mistakes in `spacedeck_spaces.js` preventing nickname choice popup to show up.

`space_auth`, the last param of `load_space` was named like global var declared in `backend.js`. So it was always undefined and it was overriding the global one.

The condition to ask for a nickname `(!this.user && space_auth)` was always false because
* `space_auth` was always undefined
* `this.user` is never equivalent to false in a public context because the object still contains a few attributes

How about allowing to choose the nickname with a GET parameter? This small change can make it much easier to integrate Spacedeck in other web apps.

Cheers