### PR TITLE
Set default stroke to 2 instead of 0

### DIFF
--- a/public/javascripts/spacedeck_sections.js
+++ b/public/javascripts/spacedeck_sections.js
@@ -62,7 +62,7 @@ var SpacedeckSections = {
 
     active_style: {
       border_radius: 0,
-      stroke: 0,
+      stroke: 2,
       font_family: "Inter",
       font_size: 36,
       line_height: 1.5,
@@ -1368,7 +1368,7 @@ var SpacedeckSections = {
     },
 
     reset_stroke: function() {
-      this.active_style.stroke = 0;
+      this.active_style.stroke = 2;
       this.active_style.border_radius = 0;
       this.active_style.stroke_style = "solid";
     },
@@ -1726,7 +1726,7 @@ var SpacedeckSections = {
         h: h,
         stroke_color: this.active_style.stroke_color,
         text_color: this.active_style.text_color,
-        stroke: 0,
+        stroke: this.active_style.stroke,
         fill_color: this.active_style.fill_color,
         shape: shape_type,
         valign: "middle",


### PR DESCRIPTION
Hi there,

Having a transparent shape fill color and a default stroke to 0 makes first shapes invisible.
This sets default stroke to 2 and uses the current "active style" stroke value for following added shapes.