### PR TITLE
protect against 'ClickJacking' attacks

### DIFF
--- a/spacedeck.js
+++ b/spacedeck.js
@@ -61,7 +61,7 @@ app.use(bodyParser.urlencoded({
 }));
 
 app.use(cookieParser());
-//app.use(helmet.frameguard())
+//app.use(helmet.frameguard({ action: 'SAMEORIGIN' }));
 //app.use(helmet.xssFilter())
 /*app.use(helmet.hsts({
   maxAge: 7776000000,


### PR DESCRIPTION
Sites can use this to avoid click-jacking attacks, by ensuring that their content is not embedded into other sites.  Because some users might want to embed their copy of spacedeck in their sites, leave this line commented out.