### PR TITLE
🐛 add opus-dev to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # build audiowaveform from source
 
-RUN apk add git make cmake gcc g++ libmad-dev libid3tag-dev libsndfile-dev gd-dev boost-dev libgd libpng-dev zlib-dev
+RUN apk add git make cmake gcc g++ libmad-dev libid3tag-dev libsndfile-dev gd-dev boost-dev libgd libpng-dev zlib-dev opus-dev
 RUN apk add zlib-static libpng-static boost-static
 
 RUN apk add autoconf automake libtool gettext


### PR DESCRIPTION
latest audiowaveform has a dependency on opus-dev and docker wouldn't build the image without having the library