### PR TITLE
Add opus-dev Dependency for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # build audiowaveform from source
 
-RUN apk add git make cmake gcc g++ libmad-dev libid3tag-dev libsndfile-dev gd-dev boost-dev libgd libpng-dev zlib-dev
+RUN apk add git make cmake gcc g++ libmad-dev libid3tag-dev opus-dev libsndfile-dev gd-dev boost-dev libgd libpng-dev zlib-dev
 RUN apk add zlib-static libpng-static boost-static
 
 RUN apk add autoconf automake libtool gettext


### PR DESCRIPTION
This fixes the docker image build introducing the missing dependency
opus-dev. Building Audiowaveform supports and requires opus to be
present for successful build since august 2021.