### PR TITLE
Allow providing auth session token via HTTP header

### DIFF
--- a/middlewares/session.js
+++ b/middlewares/session.js
@@ -23,7 +23,12 @@ module.exports = (req, res, next) => {
   }
 
   // authentication via session/cookie
-  const token = req.cookies["sdsession"];
+  let token = req.cookies["sdsession"];
+
+  if (!token || token == null) {
+    // authentication via session/header
+    token = req.headers["x-spacedeck-auth"];
+  }
 
   if (token && token != "null" && token != null) {
     db.Session.findOne({ where: { token: token } })


### PR DESCRIPTION
This allows sending the same session token, that is usually being provided via the `sdsession` cookie, via the `X-Spacedeck-Auth` HTTP header.